### PR TITLE
Bugfix: Pickit IndexError

### DIFF
--- a/src/item/pickit.py
+++ b/src/item/pickit.py
@@ -149,6 +149,8 @@ class PickIt:
                 counter += 1
                 self._log_data(items, img, counter, _uuid)
                 item_count=0
+                if not items:
+                    break
             # Otherwise continue to next item in the list
             item = items[item_count]
 


### PR DESCRIPTION
Solves the following:

```
  File "C:\Users\aliig\Desktop\bot\botty\src\run\shenk_eld.py", line 53, in battle
    picked_up_items = self._pickit.pick_up_items(self._char)
  File "C:\Users\aliig\Desktop\bot\botty\src\item\pickit.py", line 153, in pick_up_items
    item = items[item_count]
IndexError: list index out of range
```