### PR TITLE
Update diablo.py _sealdance()

### DIFF
--- a/src/run/diablo.py
+++ b/src/run/diablo.py
@@ -113,11 +113,11 @@ class Diablo:
     # OPEN SEALS
     def _sealdance(self, seal_opentemplates: list[str], seal_closedtemplates: list[str], seal_layout: str, seal_node: str) -> bool:
         i = 0
-        while i < 4:
+        while i < 8:
             Logger.debug(seal_layout + ": trying to open (try #" + str(i+1)+")")
             self._char.select_by_template(seal_closedtemplates, threshold=0.5, timeout=0.1, telekinesis=True)
             wait(i*0.5)
-            found = template_finder.search_and_wait(seal_opentemplates, threshold=0.75, timeout=0.1).valid
+            found = template_finder.search_and_wait(seal_opentemplates, threshold=0.7, timeout=0.1).valid
             if found:
                 Logger.info(seal_layout +": is open - "+'\033[92m'+" open"+'\033[0m')
                 break


### PR DESCRIPTION
I watched 10 hours of diablo run by 4 fohdins. About 30% were failed games which aborted in middle run, especially on detecting that if the seal is openned.  In almost every fail caused by this reason, the seal was openned successfully, but the decisions were closed for 5 times then the game was aborted. 

By increasing the numbers of try and reduce the seal_opentemplates threshold to 0.7, the incorrect judgements on seal's open status seldom occur. Now the ratio of failed games typically reduced. It is about 12% mostly caused by temporary high latency or getting lost after teleport to pick item.