### PR TITLE
Fix: template_finder.search() tests were terminating after first "assert"

### DIFF
--- a/test/template_finder_test.py
+++ b/test/template_finder_test.py
@@ -5,36 +5,36 @@ from utils.misc import is_in_roi
 import screen
 import utils.download_test_assets # downloads assets if they don't already exist, doesn't need to be called
 
-@pytest.mark.parametrize("template1_path, template2_path, template3_path, screen_path, expected_roi", [(
-    "test/assets/stash_slot_empty.png", # empty stash slot
-    "test/assets/stash_slot_slash.png", # empty stash slot but has a drawn slash
-    "test/assets/stash_slot_cross.png", # empty stash slot but has a drawn X
-    "test/assets/stash_slots.png", # image with three empty slots and one slot with a draw slash
-    [38, 0, 38, 38]) # region of slash
-])
-def test_match_behavior(template1_path, template2_path, template3_path, screen_path, expected_roi):
-    screen.set_window_position(0, 0)
-    image = cv2.imread(screen_path)
-    empty = cv2.imread(template1_path)
-    slash = cv2.imread(template2_path)
-    cross = cv2.imread(template3_path)
+screen.set_window_position(0, 0)
+
+image = cv2.imread("test/assets/stash_slots.png")
+empty = cv2.imread("test/assets/stash_slot_empty.png")
+slash = cv2.imread("test/assets/stash_slot_slash.png")
+cross = cv2.imread("test/assets/stash_slot_cross.png")
+slash_expected_roi = [38, 0, 38, 38]
+
+def test_search():
     threshold=0.6
     """
-    Test first match
+    Test default search behavior (first match)
     - searches first for cross, which doesn't perfectly match but should reach above threshold
     - if cross matches above threshold as expected, then it won't bother to search for slash, which has a perfect match on the image
     - test passes if the template match score is not perfect
     """
     match = template_finder.search([cross, slash], image, threshold)
     assert threshold <= match.score < 1
+
+def test_search_best_match():
     """
-    Test best match
+    Test search "best_match" behavior
     - searches first for cross, which doesn't perfectly match
     - searches next for slash, which perfectly matches on image
     - test passes if the center of the template match lies within the expected region of the slash
     """
     match = template_finder.search([cross, slash], image, threshold=0.6, best_match=True)
-    assert is_in_roi(expected_roi, match.center)
+    assert is_in_roi(slash_expected_roi, match.center)
+
+def test_search_all():
     """
     Test all matches
     - searches for empty slots with high threshold


### PR DESCRIPTION
Reorganized template_finder tests